### PR TITLE
Flake8 - set max line length to 99

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99

--- a/{{cookiecutter.project_slug}}/setup.cfg
+++ b/{{cookiecutter.project_slug}}/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = {{cookiecutter.project_slug}}
 license = Apache-2
-classifier = 
+classifier =
     License :: OSI Approved :: MIT License
 
 test_require =
@@ -13,3 +13,6 @@ addopts = --tb=short -rxs --strict
 [pydocstyle]
 match_dir = (?!tests|env|docs|\.).*
 match = (?!setup).*.py
+
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
Set `max-line-length` expected by `flake8` to 99. Must be done both on template and package level, because `flake8` seems to only respect settings in the folder from which it is run.